### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         # our matrix for testing acros node versions and OSs
         node-version: [12, 14]
-        os: [windows-2019, ubuntu-18.04, ubuntu-20.04]
+        os: [windows-2019, ubuntu-20.04]
     
     steps:
       - name: Checkout


### PR DESCRIPTION
Removed ubuntu 18.04 it's deprecated: 

https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/